### PR TITLE
request _userEmailURL when has user:email permission

### DIFF
--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -32,7 +32,7 @@ var util = require('util')
  *
  *     passport.use(new GitHubStrategy({
  *         clientID: '123-456-789',
- *         clientSecret: 'shhh-its-a-secret'
+ *         clientSecret: 'shhh-its-a-secret',
  *         callbackURL: 'https://www.example.net/auth/github/callback',
  *         userAgent: 'myapp.com'
  *       },
@@ -106,6 +106,20 @@ Strategy.prototype.userProfile = function(accessToken, done) {
     profile.provider  = 'github';
     profile._raw = body;
     profile._json = json;
+
+    var canAccessEmail = false;
+    var scopes = self._scope;
+    if (typeof scopes === 'string') {
+      scopes = scopes.split(self._scopeSeparator);
+    }
+    if (Array.isArray(scopes)) {
+      canAccessEmail = scopes.some(function(scope) {
+        return scope === 'user' || scope === 'user:email';
+      });
+    }
+    if (!canAccessEmail) {
+      return done(null, profile);
+    }
 
     // Getting emails
     self._oauth2.get(self._userEmailURL, accessToken, function (err, body, res) {


### PR DESCRIPTION
API `/user/emails`  is accessible with the `user:email` scope.
so we should better request email information when have `user` or `user:email` scope.

Refers:
[List email addresses for a user](https://developer.github.com/v3/users/emails/#list-email-addresses-for-a-user)
[Scopes](https://developer.github.com/v3/oauth/#scopes)
