### PR TITLE
feat: optionally return all raw email addresses for user

### DIFF
--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -137,9 +137,9 @@ Strategy.prototype.userProfile = function(accessToken, done) {
 
       if (self._allRawEmails) {
         profile.emails = json.map(function (email) {
-          var mappedEmail = Object.assign(email, { value: email.email });
-          delete mappedEmail.email;
-          return mappedEmail;
+          email.value = email.email;
+          delete email.email;
+          return email;
         });
       } else {
         for (var index in json) {

--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -18,15 +18,16 @@ var util = require('util')
  * credentials are not valid.  If an exception occured, `err` should be set.
  *
  * Options:
- *   - `clientID`      your GitHub application's Client ID
- *   - `clientSecret`  your GitHub application's Client Secret
- *   - `callbackURL`   URL to which GitHub will redirect the user after granting authorization
- *   - `scope`         array of permission scopes to request. Valid scopes include:
- *                     'user', 'public_repo', 'repo', 'gist', or none.
- *                     (see http://developer.github.com/v3/oauth/#scopes for more info)
- *   — `userAgent`     All API requests MUST include a valid User Agent string.
- *                     e.g: domain name of your application.
- *                     (see http://developer.github.com/v3/#user-agent-required for more info)
+ *   - `clientID`     your GitHub application's Client ID
+ *   - `clientSecret` your GitHub application's Client Secret
+ *   - `callbackURL`  URL to which GitHub will redirect the user after granting authorization
+ *   - `scope`        array of permission scopes to request. Valid scopes include:
+ *                    'user', 'public_repo', 'repo', 'gist', or none.
+ *                    (see http://developer.github.com/v3/oauth/#scopes for more info)
+ *   — `userAgent`    All API requests MUST include a valid User Agent string.
+ *                    e.g: domain name of your application.
+ *                    (see http://developer.github.com/v3/#user-agent-required for more info)
+ *   — `allRawEmails` boolean to indicate whether to return all raw email addresses or just the primary
  *
  * Examples:
  *
@@ -63,6 +64,7 @@ function Strategy(options, verify) {
   this._userProfileURL = options.userProfileURL || 'https://api.github.com/user';
   this._userEmailURL = options.userEmailURL || 'https://api.github.com/user/emails';
   this._oauth2.useAuthorizationHeaderforGET(true);
+  this._allRawEmails = options.allRawEmails || false;
 }
 
 /**
@@ -129,10 +131,22 @@ Strategy.prototype.userProfile = function(accessToken, done) {
 
       var json = JSON.parse(body);
 
-      for (var index in json) {
-        if (json[index].primary) {
-          profile.emails = [{ value: json[index].email }];
-          break;
+      if (!json || !json.length) {
+        return done(new Error('Failed to fetch user emails'));
+      }
+
+      if (self._allRawEmails) {
+        profile.emails = json.map(function (email) {
+          var mappedEmail = Object.assign(email, { value: email.email });
+          delete mappedEmail.email;
+          return mappedEmail;
+        });
+      } else {
+        for (var index in json) {
+          if (json[index].primary) {
+            profile.emails = [{ value: json[index].email }];
+            break;
+          }
         }
       }
 

--- a/test/strategy.options.test.js
+++ b/test/strategy.options.test.js
@@ -61,5 +61,69 @@ describe('Strategy#userProfile', function() {
       expect(profile._json).to.be.an('object');
     });
   });
+
+  describe('loading profile to return all raw emails', function() {
+    var strategy =  new GitHubStrategy({
+        clientID: 'ABC123',
+        clientSecret: 'secret',
+        scope: [ 'user:email' ],
+        allRawEmails: true
+      },
+      function() {});
+
+    // mock
+    strategy._oauth2.get = function(url, accessToken, callback) {
+      var testcases = {
+        'https://api.github.com/user': '{ "login": "octocat", "id": 1, "name": "monalisa octocat", "email": "octocat@github.com", "avatar_url": "https://avatars1.githubusercontent.com/u/583231?v=3&s=460", "html_url": "https://github.com/octocat" }',
+        'https://api.github.com/user/emails': '[ { "email": "octocat@github.com", "verified": true, "primary": true }, { "email": "nonprimarybutverified@github.com", "verified": true, "primary": false }, { "email": "unverified@pineapple.com", "verified": false, "primary": false } ]'
+      };
+
+      var body = testcases[url] || null;
+      if (!body)
+        return callback(new Error('wrong url argument'));
+
+      if (accessToken != 'token') { return callback(new Error('wrong token argument')); }
+  
+      callback(null, body, undefined);
+    };
+    
+    
+    var profile;
+    
+    before(function(done) {
+      strategy.userProfile('token', function(err, p) {
+        if (err) { return done(err); }
+        profile = p;
+        done();
+      });
+    });
+    
+    it('should parse profile', function() {
+      expect(profile.provider).to.equal('github');
+
+      expect(profile.id).to.equal('1');
+      expect(profile.username).to.equal('octocat');
+      expect(profile.displayName).to.equal('monalisa octocat');
+      expect(profile.profileUrl).to.equal('https://github.com/octocat');
+      expect(profile.emails).to.have.length(3);
+      expect(profile.emails[0].value).to.equal('octocat@github.com');
+      expect(profile.emails[0].verified).to.equal(true);
+      expect(profile.emails[0].primary).to.equal(true);
+      expect(profile.emails[1].value).to.equal('nonprimarybutverified@github.com');
+      expect(profile.emails[1].verified).to.equal(true);
+      expect(profile.emails[1].primary).to.equal(false);
+      expect(profile.emails[2].value).to.equal('unverified@pineapple.com');
+      expect(profile.emails[2].verified).to.equal(false);
+      expect(profile.emails[2].primary).to.equal(false);
+    });
+    
+    it('should set raw property', function() {
+      expect(profile._raw).to.be.a('string');
+    });
+    
+    it('should set json property', function() {
+      expect(profile._json).to.be.an('object');
+    });
+  });
   
 });

--- a/test/strategy.options.test.js
+++ b/test/strategy.options.test.js
@@ -27,13 +27,13 @@ describe('Strategy#userProfile', function() {
         return callback(new Error('wrong url argument'));
 
       if (accessToken != 'token') { return callback(new Error('wrong token argument')); }
-  
+
       callback(null, body, undefined);
     };
-    
-    
+
+
     var profile;
-    
+
     before(function(done) {
       strategy.userProfile('token', function(err, p) {
         if (err) { return done(err); }
@@ -41,7 +41,7 @@ describe('Strategy#userProfile', function() {
         done();
       });
     });
-    
+
     it('should parse profile', function() {
       expect(profile.provider).to.equal('github');
       
@@ -52,11 +52,11 @@ describe('Strategy#userProfile', function() {
       expect(profile.emails).to.have.length(1);
       expect(profile.emails[0].value).to.equal('octocat@github.com');
     });
-    
+
     it('should set raw property', function() {
       expect(profile._raw).to.be.a('string');
     });
-    
+
     it('should set json property', function() {
       expect(profile._json).to.be.an('object');
     });
@@ -83,13 +83,13 @@ describe('Strategy#userProfile', function() {
         return callback(new Error('wrong url argument'));
 
       if (accessToken != 'token') { return callback(new Error('wrong token argument')); }
-  
+
       callback(null, body, undefined);
     };
-    
-    
+
+
     var profile;
-    
+
     before(function(done) {
       strategy.userProfile('token', function(err, p) {
         if (err) { return done(err); }
@@ -97,7 +97,7 @@ describe('Strategy#userProfile', function() {
         done();
       });
     });
-    
+
     it('should parse profile', function() {
       expect(profile.provider).to.equal('github');
 
@@ -116,11 +116,11 @@ describe('Strategy#userProfile', function() {
       expect(profile.emails[2].verified).to.equal(false);
       expect(profile.emails[2].primary).to.equal(false);
     });
-    
+
     it('should set raw property', function() {
       expect(profile._raw).to.be.a('string');
     });
-    
+
     it('should set json property', function() {
       expect(profile._json).to.be.an('object');
     });


### PR DESCRIPTION
Adopted in part from https://github.com/jaredhanson/passport-github/pull/27

When a user has multiple github email addresses, only their first one is being returned. This PR adds the strategy constructor option to return all email addresses in their raw response form, to allow for downstream decisions about how to handle multiple email addresses.