### PR TITLE
fix: allRawEmails comments

### DIFF
--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -27,7 +27,7 @@ var util = require('util')
  *   — `userAgent`    All API requests MUST include a valid User Agent string.
  *                    e.g: domain name of your application.
  *                    (see http://developer.github.com/v3/#user-agent-required for more info)
- *   — `allRawEmails` boolean to indicate whether to return all raw email addresses or just the primary
+ *   — `allRawEmails` boolean to indicate whether to return all raw email addresses or just the public
  *
  * Examples:
  *
@@ -88,7 +88,7 @@ util.inherits(Strategy, OAuth2Strategy);
  * @param {Function} done
  * @api protected
  */
-Strategy.prototype.userProfile = function(accessToken, done) {
+Strategy.prototype.userProfile = function (accessToken, done) {
   var self = this;
 
   this._oauth2.get(this._userProfileURL, accessToken, function (err, body, res) {
@@ -105,7 +105,7 @@ Strategy.prototype.userProfile = function(accessToken, done) {
     }
 
     var profile = Profile.parse(json);
-    profile.provider  = 'github';
+    profile.provider = 'github';
     profile._raw = body;
     profile._json = json;
 
@@ -115,7 +115,7 @@ Strategy.prototype.userProfile = function(accessToken, done) {
       scopes = scopes.split(self._scopeSeparator);
     }
     if (Array.isArray(scopes)) {
-      canAccessEmail = scopes.some(function(scope) {
+      canAccessEmail = scopes.some(function (scope) {
         return scope === 'user' || scope === 'user:email';
       });
     }


### PR DESCRIPTION
# fix: allRawEmails comments

## Summary 

For some reason if you let the allRawEmails option in false, it bring only the public email, not the primary one.

```
      if (self._allRawEmails) {
        profile.emails = json.map(function (email) {
          email.value = email.email;
          delete email.email;
          return email;
        });
      }
```

This code have sense, may be is Github messing it. WEIRD!!!